### PR TITLE
Changing the Event to Service name 

### DIFF
--- a/notifier/alerta-notifier.go
+++ b/notifier/alerta-notifier.go
@@ -97,7 +97,7 @@ func (al *AlertaNotifier) Notify(messages Messages) bool {
 			Environment: al.Environment,
 			Services:    []string{message.Service},
 			Resource:    message.Node,
-			Event:       message.Status,
+			Event:       message.Service,
 			Value:       message.Status,
 			Status:      status,
 			Severity:    severity,


### PR DESCRIPTION
Alerta is not correlating events when the Status is used as the Event. This isn't ideal, as the Event should really be something along the lines of "Service down" or "Process stopped" but the only place consul would report something like that is in the Text, which is simply the output returned from the consul check. Being that we can't control what people create as checks, using Text as Event is probably a bad idea. So we'll use Service instead.
